### PR TITLE
Fixes product images

### DIFF
--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -12,7 +12,7 @@ const Product = ({ image, product, productId }) => {
     <div className={styles.container}>
       {product.images && (
         <div className={styles.image}>
-          <Img fluid={product.images?.edges[0]?.node} />
+          <img src={product.images?.edges[0]?.node.transformedSrc} />
         </div>
       )}
       <div className={styles.text}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -71,7 +71,7 @@ const Product = ({ _id, name, image, shopifyProductId, shopifyProduct }) => {
     <div className={styles.product}>
       {shopifyProduct.images && (
         <Link className={styles.productImage} to={routes.products(name)}>
-          <Img fluid={shopifyProduct.images?.edges[0]?.node} />
+          <img src={shopifyProduct.images?.edges[0]?.node.transformedSrc} />
         </Link>
       )}
       <div className={styles.productLabel}>

--- a/src/styles/index.module.css
+++ b/src/styles/index.module.css
@@ -75,6 +75,11 @@
   border-radius: 4px;
 }
 
+.productImage img {
+  width: 100%;
+  height: auto;
+}
+
 .productLabel {
   flex: 1 1 auto;
   padding: 1em;


### PR DESCRIPTION
When the project was updated to use images from Shopify, we also needed to use vanilla img tags to display them.

### Test steps

1. Checkout branch
1. `npm run develop`
1. Check out images load correctly on index page and product pages